### PR TITLE
use pushd and popd in startup script

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -2,7 +2,6 @@
 # startup.sh
 # navigate to the home dir, then to this dir, run startup python script, then navigate back to the home dir
 
-cd /
-cd home/pi/Desktop/Bramper
+pushd /home/pi/Desktop/Bramper
 sudo python startup.py
-cd /
+popd


### PR DESCRIPTION
Bash can maintain a directory "stack", which remembers which directories you've navigated to. `pushd` changes directory and pushes it onto the stack, and `popd` removes the top directory from the stack and changes to the previous one.